### PR TITLE
I've updated the README.md file with a "Demonstration" section.

### DIFF
--- a/javascript/react-ts/README.md
+++ b/javascript/react-ts/README.md
@@ -60,3 +60,26 @@ yarn add -D @typescript-eslint/eslint-plugin@^5.0.0 @typescript-eslint/parser@^5
 *   **`eslint-plugin-react-hooks`**: This plugin is crucial for React projects using Hooks. It enforces the Rules of Hooks (e.g., only call Hooks at the top level, only call Hooks from React functions), which helps prevent common bugs and ensures Hooks behave as expected.
 *   **`eslint-plugin-jsx-a11y`**: Accessibility is a vital aspect of web development. This plugin helps identify and enforce accessibility best practices in your JSX, making your application more usable for people with disabilities. It checks for things like proper ARIA attributes, image alt text, and keyboard navigability.
 ```
+
+## Demonstration
+
+To illustrate how this ESLint and Prettier setup works, an example component `example/UserProfile.tsx` has been included. This file intentionally contains a few common linting and formatting errors.
+
+If you run the lint script (`npm run lint` or `yarn lint`) in a project containing this example file (and the provided ESLint configuration), you would expect to see error messages similar to the following:
+
+```text
+path/to/your/project/javascript/react-ts/example/UserProfile.tsx
+  17:5  Error: The `useState` hook returns an array of two elements. We expect the second element to be the updater function, not to be never reassigned.  @typescript-eslint/no-unused-vars
+  23:7  Error: React Hook useEffect has a missing dependency: 'name'. Either include it or remove the dependency array.  react-hooks/exhaustive-deps
+  29:7  Error: img elements must have an alt prop, either with meaningful text, or an empty string for decorative images.  jsx-a11y/alt-text
+
+✖ 3 problems (3 errors, 0 warnings)
+```
+
+**Explanation of Errors:**
+
+*   **`@typescript-eslint/no-unused-vars`**: This error (shown here for `setUnusedSetter`) flags variables that are declared but never used. In the example, the `setUnusedSetter` function from a `useState` call is intentionally not used.
+*   **`react-hooks/exhaustive-deps`**: This rule ensures that all dependencies of `useEffect`, `useCallback`, etc., are correctly listed in their dependency arrays. The example component intentionally omits `name` from `useEffect`'s dependency array.
+*   **`jsx-a11y/alt-text`**: This accessibility rule requires `<img>` elements to have an `alt` attribute, which is crucial for screen readers and for situations where the image cannot be displayed. The example `<img>` tag is missing this attribute.
+
+Additionally, the `UserProfile.tsx` file contains some inconsistent formatting (like mixed single and double quotes for strings, and varied indentation). Running the format script (`npm run format` or `yarn format`) will automatically correct these inconsistencies according to the rules defined in `.prettierrc`.


### PR DESCRIPTION
- I added a new 'Demonstration' section to `javascript/react-ts/README.md`.
- This section explains the purpose of the `example/UserProfile.tsx` component.
- It includes example linter output for common errors (jsx-a11y/alt-text, no-unused-vars, react-hooks/exhaustive-deps).
- It also explains that `npm run format` will fix formatting issues.