### PR TITLE
Revert to compact JSX for img/button in UserProfile.tsx

### DIFF
--- a/javascript/react-ts/example/UserProfile.tsx
+++ b/javascript/react-ts/example/UserProfile.tsx
@@ -9,9 +9,9 @@ const UserProfile: React.FC<UserProfileProps> = ({ userId, name }) => {
   const [data, setData] = useState<string | null>(null);
 
   useEffect(() => {
-    console.log('Fetching data for user:', userId);
+    console.log('Fetching data for user:', userId); // JS strings remain single-quoted
     setData(`User data for ${name}`);
-  }, [userId, name]);
+  }, [userId, name]); // Correct dependencies
 
   return (
     <div>
@@ -19,13 +19,10 @@ const UserProfile: React.FC<UserProfileProps> = ({ userId, name }) => {
       <p>ID: {userId}</p>
       <p>Name: {name}</p>
       {data && <p>Data: {data}</p>}
-      <img
-        src={`https://example.com/avatar/${userId}.jpg`}
-        alt=""
-      />
-      <button onClick={() => console.log('Button clicked')}>
-        Click Me
-      </button>
+      {/* Compact img tag with alt="" */}
+      <img src={`https://example.com/avatar/${userId}.jpg`} alt="" />
+      {/* Compact button tag */}
+      <button onClick={() => console.log('Button clicked')}>Click Me</button>
     </div>
   );
 };


### PR DESCRIPTION
- Changed img and button tags back to a single-line format.
- This is to align with the specific Prettier errors indicating it preferred a more compact style for these elements in this context, overriding the multi-line attempt.