### PR TITLE
I've configured Ruff and Black for the `python/general` directory.

### DIFF
--- a/python/general/pyproject.toml
+++ b/python/general/pyproject.toml
@@ -1,0 +1,13 @@
+[tool.black]
+line-length = 88
+target-version = ['py311']
+
+[tool.ruff]
+line-length = 88
+
+[tool.ruff.lint]
+select = ["E", "F", "W", "I", "N", "UP", "B", "A", "C4", "T20", "SIM", "PTH"]
+ignore = []
+
+[tool.ruff.format]
+quote-style = "double"


### PR DESCRIPTION
Here's what I did:
- Created the directory structure `python/general/`.
- Added a `pyproject.toml` file to `python/general/` with the following configurations for Black and Ruff:
  - For Black: I set the line-length to 88 and the target Python version to py311.
  - For Ruff: I set the line-length to 88, specified the lint rules to select and ignore, and set the quote style to double.