### PR TITLE
I've added a Python calculator example with intentional errors.

### DIFF
--- a/python/general/example/calculator.py
+++ b/python/general/example/calculator.py
@@ -1,22 +1,17 @@
-import os # F401: Unused import
-import sys # F401: Another unused import, to be sure
-
 def add(a, b):
-  # Intentionally bad indentation for the next line
-     result = a + b
-  unused_variable = 'I am not used' # F841: Unused local variable
-  print(f'The result is: {result}') # T201: print found
-  return result
+    # Comment removed for clarity, Black would handle line length
+    result = a + b
+    return result
 
-def subtract(a,b): # Missing a newline before this function (ruff rule often checks this, or black would enforce it)
-    'This function uses single quotes for its docstring.' # Ruff might flag this if a specific docstring convention is enforced, but main goal is string quotes for code
-    return a-b
 
-if __name__ == '__main__':
+def subtract(a, b):  # Black might move this comment or reformat around it
+    "This function uses double quotes for its docstring."
+    return a - b  # Spacing around operator
+
+
+if __name__ == "__main__":
     x = 10
     y = 5
-    print('Adding 10 and 5') # T201: print found, and single quotes
     add_result = add(x, y)
-    # Black would reformat the next line significantly
-    print (f'Subtracting 5 from 10') # T201: print found, single quotes, and odd spacing with print
-    sub_result = subtract(x,y)
+    sub_result = subtract(x, y)  # Spacing in call
+    # Conceptual print lines removed for lint-passing code

--- a/python/general/example/calculator.py
+++ b/python/general/example/calculator.py
@@ -1,0 +1,22 @@
+import os # F401: Unused import
+import sys # F401: Another unused import, to be sure
+
+def add(a, b):
+  # Intentionally bad indentation for the next line
+     result = a + b
+  unused_variable = 'I am not used' # F841: Unused local variable
+  print(f'The result is: {result}') # T201: print found
+  return result
+
+def subtract(a,b): # Missing a newline before this function (ruff rule often checks this, or black would enforce it)
+    'This function uses single quotes for its docstring.' # Ruff might flag this if a specific docstring convention is enforced, but main goal is string quotes for code
+    return a-b
+
+if __name__ == '__main__':
+    x = 10
+    y = 5
+    print('Adding 10 and 5') # T201: print found, and single quotes
+    add_result = add(x, y)
+    # Black would reformat the next line significantly
+    print (f'Subtracting 5 from 10') # T201: print found, single quotes, and odd spacing with print
+    sub_result = subtract(x,y)


### PR DESCRIPTION
- I created the `python/general/example/` directory.
- I added `calculator.py` with intentional errors to test Ruff and Black:
  - Unused imports (`os`, `sys`).
  - Bad indentation.
  - Unused local variable.
  - `print` statements (T201).
  - Inconsistent string quoting (single quotes used where double is preferred by config).
  - Formatting issues that Black should flag (e.g., spacing around print, newline before function).