### PR TITLE
I've added VS Code settings for React+TS ESLint/Prettier.

### DIFF
--- a/javascript/react-ts/.vscode/settings.json
+++ b/javascript/react-ts/.vscode/settings.json
@@ -1,0 +1,19 @@
+{
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": "explicit"
+  },
+  "editor.formatOnSave": true,
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "[javascript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[javascriptreact]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[typescript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[typescriptreact]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  }
+}


### PR DESCRIPTION
- I created `javascript/react-ts/.vscode/settings.json`.
- This configures VS Code to auto-fix ESLint errors when you save.
- It also sets Prettier (via esbenp.prettier-vscode) as the default formatter for your JS/TS files and enables formatting when you save.