### PR TITLE
Add react to devDependencies for ESLint version detection

### DIFF
--- a/javascript/react-ts/package.json
+++ b/javascript/react-ts/package.json
@@ -20,6 +20,7 @@
     "eslint-plugin-react": "^7.0.0",
     "eslint-plugin-react-hooks": "^4.0.0",
     "prettier": "^2.0.0",
+    "react": "^18.3.0",
     "typescript": "^4.0.0"
   }
 }


### PR DESCRIPTION
- Added "react": "^18.3.0" to `devDependencies` in `javascript/react-ts/package.json`.
- This allows `eslint-plugin-react` to correctly detect the React version and resolves a common ESLint warning when 'react' is not explicitly listed as a dependency.