### PR TITLE
I've added Jekyll configuration for GitHub Pages.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,3 @@
+theme: jekyll-theme-minimal
+title: Linter Hub: Curated Code Quality Configs
+description: A collection of ready-to-use, explained linter and formatter configurations for various tech stacks.


### PR DESCRIPTION
I created a `_config.yml` file in the root directory to set up a GitHub Pages site using Jekyll.

- Theme: jekyll-theme-minimal
- Title: Linter Hub: Curated Code Quality Configs
- Description: A collection of ready-to-use, explained linter and formatter configurations for various tech stacks.