### PR TITLE
I noticed the GitHub Actions build for Jekyll failed due to a YAML sy…

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,3 +1,3 @@
 theme: jekyll-theme-minimal
-title: Linter Hub: Curated Code Quality Configs
+title: "Linter Hub: Curated Code Quality Configs"
 description: A collection of ready-to-use, explained linter and formatter configurations for various tech stacks.


### PR DESCRIPTION
…ntax error in `_config.yml`. It appears the `title` field contained an unquoted colon.

I've prepared a commit that should fix this by enclosing the title string in quotes.